### PR TITLE
Remove IDE Specific settings + Add Editor Config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[package.json]
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-}


### PR DESCRIPTION
IDE Specific settings shouldn't be in the repos.

I'm removing the VS Code specific file and adding the dotfile EditorConfig for common ide settings. 

It should help to be consistent everywhere...
